### PR TITLE
feat(api): add server login route

### DIFF
--- a/packages/api/src/app.controller.ts
+++ b/packages/api/src/app.controller.ts
@@ -1,4 +1,6 @@
 import { Controller, Get } from '@nestjs/common';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
 
 @Controller()
 export class AppController {
@@ -7,5 +9,15 @@ export class AppController {
   @Get()
   getHello(): string {
     return 'Hello World!';
+  }
+
+  @Get('login')
+  getLogin(): string {
+    const indexPath = join(__dirname, '..', '..', 'admin', 'index.html');
+    if (existsSync(indexPath)) {
+      return readFileSync(indexPath, 'utf8');
+    }
+
+    return 'Login page is handled on the client. Use the /auth endpoints to sign in.';
   }
 }


### PR DESCRIPTION
## Summary
- add `/login` route to API to deliver static login page or instructions

## Testing
- `npm test` *(fails: Feedbacks CRUD should create feedback with valid data)*

------
https://chatgpt.com/codex/tasks/task_b_68b01921d74c833298927ee9a6567bce