### PR TITLE
fix(api): serve login page correctly

### DIFF
--- a/packages/api/src/app.controller.ts
+++ b/packages/api/src/app.controller.ts
@@ -1,4 +1,6 @@
 import { Controller, Get } from '@nestjs/common';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
 
 @Controller()
 export class AppController {
@@ -7,5 +9,17 @@ export class AppController {
   @Get()
   getHello(): string {
     return 'Hello World!';
+  }
+
+  @Get('login')
+  getLogin(): string {
+    const buildPath = join(__dirname, '..', '..', '..', 'admin', 'dist', 'index.html');
+    const devPath = join(__dirname, '..', '..', '..', 'admin', 'index.html');
+    const indexPath = existsSync(buildPath) ? buildPath : devPath;
+    if (existsSync(indexPath)) {
+      return readFileSync(indexPath, 'utf8');
+    }
+
+    return 'Login page is handled on the client. Use the /auth endpoints to sign in.';
   }
 }


### PR DESCRIPTION
## Summary
- ensure `/login` serves the admin index for both dev and build

## Testing
- `npm test` *(fails: @prisma/client did not initialize yet. Please run "prisma generate" and try to import it again.)*

------
https://chatgpt.com/codex/tasks/task_b_68b01921d74c833298927ee9a6567bce