### PR TITLE
Fix /login route 404

### DIFF
--- a/packages/admin/src/App.tsx
+++ b/packages/admin/src/App.tsx
@@ -107,11 +107,11 @@ const App = () => {
                     </Authenticated>
                   }
                 >
-                  <Route path="/login" element={<PageLogin />} />
-                  <Route path="/login/email" element={<PageLoginWithEmail />} />
-                  <Route path="/signup" element={<PageSignup />} />
+                  <Route path="login" element={<PageLogin />} />
+                  <Route path="login/email" element={<PageLoginWithEmail />} />
+                  <Route path="signup" element={<PageSignup />} />
                   <Route
-                    path="/signup/email"
+                    path="signup/email"
                     element={<PageSignupWithEmail />}
                   />
                 </Route>


### PR DESCRIPTION
## Summary
- fix login routes to avoid 404

## Testing
- `npm run lint`
- `npm test` *(fails: @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_b_68b01eb0f4c88332b542397ff52b8bd3