### PR TITLE
feat: serve admin build from API and add SPA rewrites

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "lerna run build --include-dependencies",
+    "build": "lerna run build --include-dependencies && cp -r packages/admin/dist packages/api/dist/admin",
     "dev": "lerna run dev --stream --parallel --include-dependencies",
     "lint": "eslint \"**/*.{ts,tsx}\"",
     "lint:fix": "eslint --fix \"**/*.{ts,tsx}\"",

--- a/packages/admin/vercel.json
+++ b/packages/admin/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}

--- a/packages/api/src/app.controller.ts
+++ b/packages/api/src/app.controller.ts
@@ -13,9 +13,21 @@ export class AppController {
 
   @Get('login')
   getLogin(): string {
-    const indexPath = join(__dirname, '..', '..', 'admin', 'index.html');
-    if (existsSync(indexPath)) {
-      return readFileSync(indexPath, 'utf8');
+    const builtIndexPath = join(__dirname, 'admin', 'index.html');
+    if (existsSync(builtIndexPath)) {
+      return readFileSync(builtIndexPath, 'utf8');
+    }
+
+    const devIndexPath = join(
+      __dirname,
+      '..',
+      '..',
+      'admin',
+      'dist',
+      'index.html',
+    );
+    if (existsSync(devIndexPath)) {
+      return readFileSync(devIndexPath, 'utf8');
     }
 
     return 'Login page is handled on the client. Use the /auth endpoints to sign in.';


### PR DESCRIPTION
## Summary
- serve built admin index.html on /login
- copy admin build into API output during root build
- add Vercel SPA rewrite for admin

## Testing
- `npm run lint`
- `npm test` (fails: expected { id: 'test', device: 'test', …(12) } to deeply equal { id: 'test', device: 'test', …(10) })

------
https://chatgpt.com/codex/tasks/task_b_68b025bbab348332bc1ce8440fc2e616