### PR TITLE
feat(admin): use Supabase auth for user and session checks

### DIFF
--- a/packages/admin/src/data-hooks/useMe.ts
+++ b/packages/admin/src/data-hooks/useMe.ts
@@ -1,11 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
-import { fetchers } from "@/lib/fetchers";
-import type { MeResponse } from "@/types";
+import { supabase } from "@/lib/supabase";
+import type { User } from "@supabase/supabase-js";
 
 export const useMe = () => {
-  const result = useQuery<MeResponse>({
+  const result = useQuery<User | null>({
     queryKey: ["me"],
-    queryFn: () => fetchers.me(),
+    queryFn: async () => {
+      const { data } = await supabase.auth.getUser();
+      return data.user;
+    },
     retry: false,
     refetchOnWindowFocus: false,
     meta: {


### PR DESCRIPTION
## Summary
- use Supabase auth to fetch current user in `useMe`
- check Supabase session directly in `Authenticated` wrapper

## Testing
- `npm test` *(fails: @prisma/client did not initialize yet)*
- `npm run lint` *(fails: @typescript-eslint/no-unsafe-call etc.)*


------
https://chatgpt.com/codex/tasks/task_b_68b03f1b93d0833291a0d7eb6d37f2b1