### PR TITLE
chore(api): set Supabase database URL

### DIFF
--- a/packages/api/.env
+++ b/packages/api/.env
@@ -1,0 +1,1 @@
+DATABASE_URL="postgresql://postgres:postgres@db.supabase.co:5432/postgres"


### PR DESCRIPTION
## Summary
- configure API to use Supabase Postgres via DATABASE_URL
- regenerate Prisma Client for updated connection

## Testing
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_b_68b043e3260c8332a9298e19bdb724dd