### PR TITLE
fix: resolve vitest dependency issue

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -72,8 +72,8 @@
     "@types/ua-parser-js": "^0.7.39",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "@typescript-eslint/parser": "^6.15.0",
-    "@vitest/coverage-v8": "^0.34.6",
-    "@vitest/ui": "^0.34.6",
+    "@vitest/coverage-v8": "0.34.7",
+    "@vitest/ui": "0.34.7",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",
     "eslint-plugin-prettier": "^5.0.1",
@@ -86,7 +86,7 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.2.2",
     "unplugin-swc": "^1.4.3",
-    "vitest": "^0.34.6",
+    "vitest": "0.34.7",
     "vitest-mock-extended": "^1.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- remove empty package-lock that broke npm install
- align vitest and related dependencies in api package

## Testing
- `npm test` *(fails: Failed to load url @supabase/supabase-js)*

------
https://chatgpt.com/codex/tasks/task_b_68b0471b2e5c833295f9b9d4d22f55dc