### PR TITLE
chore: add vitest dev deps to root

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
     "nuke:node_modules": "lerna clean --yes"
   },
   "devDependencies": {
+    "@vitest/ui": "0.34.7",
     "eslint": "^8.56.0",
     "lerna": "^8.0.0",
-    "prettier": "^3.0.0"
+    "prettier": "^3.0.0",
+    "vitest": "0.34.7"
   },
   "name": "dropfeedback",
   "packageManager": "npm@10.2.0",


### PR DESCRIPTION
## Summary
- add vitest and @vitest/ui dev dependencies in workspace root

## Testing
- `npm test` (fails: lerna not found)
- `npm install --package-lock-only --offline` (fails: unable to resolve dependency tree)


------
https://chatgpt.com/codex/tasks/task_b_68b0492cc5dc8332be22a31bd84bc9c1