### PR TITLE
docs: add workspace install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ After you have cloned the repository, you need to install the dependencies.
 npm install
 ```
 
+To ensure all package-specific dev dependencies are available across the workspace, bootstrap the packages:
+
+```bash
+npm install --workspaces
+# or
+npx lerna bootstrap
+```
+
 ### Start the development server
 
 After you have installed the dependencies, you can start the development server by running the following command. This will start the development server of each given package.


### PR DESCRIPTION
## Summary
- document installing dev deps across all workspaces

## Testing
- `npm install --workspaces` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@typescript-eslint%2feslint-plugin)*
- `npx lerna bootstrap` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lerna)*
- `npm test` *(fails: sh: 1: lerna: not found)*


------
https://chatgpt.com/codex/tasks/task_b_68b04f62282083329541dd04bbaf22dc