### PR TITLE
chore: remove unused vitest ui dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "nuke:node_modules": "lerna clean --yes"
   },
   "devDependencies": {
-    "@vitest/ui": "0.34.7",
     "eslint": "^8.56.0",
     "lerna": "^8.0.0",
     "prettier": "^3.0.0",


### PR DESCRIPTION
## Summary
- remove @vitest/ui dev dependency
- ensure vitest remains pinned to 0.34.7

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@typescript-eslint%2feslint-plugin)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@typescript-eslint%2feslint-plugin)*
- `npm install --force` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@typescript-eslint%2feslint-plugin)*
- `npm test` *(fails: lerna: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b05483aaf48332a81252c6221a48d0