### PR TITLE
chore: upgrade vitest to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "eslint": "^8.56.0",
     "lerna": "^8.0.0",
     "prettier": "^3.0.0",
-    "vitest": "^2.0.0"
+    "vitest": "^3.0.0"
   },
   "name": "dropfeedback",
   "packageManager": "npm@10.2.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -72,7 +72,7 @@
     "@types/ua-parser-js": "^0.7.39",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "@typescript-eslint/parser": "^6.15.0",
-    "@vitest/coverage-v8": "^2.0.0",
+    "@vitest/coverage-v8": "^3.0.0",
     "dotenv": "^16.3.1",
     "eslint": "^8.56.0",
     "eslint-plugin-prettier": "^5.0.1",
@@ -85,7 +85,7 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.2.2",
     "unplugin-swc": "^1.4.3",
-    "vitest": "^2.0.0",
+    "vitest": "^3.0.0",
     "vitest-mock-extended": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- bump vitest to v3 across repo
- align api package coverage plugin with vitest v3

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@typescript-eslint%2feslint-plugin)*
- `npm test` *(fails: sh: 1: lerna: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b05948a2f883329c6aaec77965b70d