### PR TITLE
fix admin build config for tsc references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,9 +36,14 @@ yarn-error.log*
 .vercel
 dist
 
-# temporary files for cloudflare workers 
+# temporary files for cloudflare workers
 packages/web/.wrangler
 # remix build output. cloudflare uses this to build the worker
 packages/web/functions
 apps/api/src/metadata.ts
+
+# TypeScript build artifacts
+*.tsbuildinfo
+**/vite.config.js
+**/vite.config.d.ts
 

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc -b && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "format": "prettier --write .",
     "preview": "vite preview"

--- a/packages/admin/tsconfig.json
+++ b/packages/admin/tsconfig.json
@@ -24,6 +24,6 @@
       "@/*": ["./src/*"],
     },
   },
-  "include": ["src", "vite.config.ts"],
+  "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }],
 }


### PR DESCRIPTION
## Summary
- fix admin build script to use `tsc -b` and exclude Vite config from main tsconfig
- ignore TypeScript build artifacts such as `*.tsbuildinfo` and generated Vite config files

## Testing
- `npm run build` (fails: Cannot find module 'react')

------
https://chatgpt.com/codex/tasks/task_b_68b05bc19ef0833281594b516a6531fc