### PR TITLE
refactor: use fetchers for current user

### DIFF
--- a/packages/admin/src/data-hooks/useMe.ts
+++ b/packages/admin/src/data-hooks/useMe.ts
@@ -1,13 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/lib/supabase";
-import type { User } from "@supabase/supabase-js";
+import { fetchers } from "@/lib/fetchers";
+import type { MeResponse } from "@/types";
 
 export const useMe = () => {
-  const result = useQuery<User | null>({
+  const result = useQuery<MeResponse | null>({
     queryKey: ["me"],
     queryFn: async () => {
-      const { data } = await supabase.auth.getUser();
-      return data.user;
+      try {
+        const data = await fetchers.me();
+        return data;
+      } catch {
+        return null;
+      }
     },
     retry: false,
     refetchOnWindowFocus: false,


### PR DESCRIPTION
## Summary
- use API fetcher for the current user instead of Supabase auth
- type current-user hook with `MeResponse`

## Testing
- `npx tsc -p packages/admin/tsconfig.json --noEmit` *(fails: Cannot find module '@tanstack/react-query-devtools' or its corresponding type declarations)*
- `npm install` *(fails: 403 Forbidden fetching @typescript-eslint/eslint-plugin)*

------
https://chatgpt.com/codex/tasks/task_b_68b0601b734c83328b653e8a13835fe9